### PR TITLE
Add schema detection

### DIFF
--- a/tap_parquet/tap.py
+++ b/tap_parquet/tap.py
@@ -1,8 +1,9 @@
 """Parquet tap class."""
 
-from pathlib import Path
 from typing import List
-import click
+
+import pyarrow.parquet as pq
+
 from singer_sdk import Tap, Stream
 from singer_sdk.typing import (
     ArrayType,
@@ -14,12 +15,10 @@ from singer_sdk.typing import (
     PropertiesList,
     Property,
     StringType,
+    JSONTypeHelper,
 )
 
-# TODO: Import your custom stream types here:
-from tap_parquet.streams import (
-    ParquetStream,
-)
+from tap_parquet.streams import ParquetStream
 
 
 class TapParquet(Tap):
@@ -34,26 +33,13 @@ class TapParquet(Tap):
 
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
-        result: List[Stream] = []
-        for filename in [self.config["filepath"]]:
-            new_stream = ParquetStream(
+        return [
+            ParquetStream(
                 tap=self,
                 name=filename,
-                schema=self.detect_json_schema(filename),
             )
-            new_stream.primary_keys = self.detect_primary_keys(filename)
-            result.append(new_stream)
-        return result
-
-    def detect_json_schema(self, parquet_filepath: str) -> dict:
-        return PropertiesList(
-            Property("f0", StringType, required=True),
-            Property("f1", StringType),
-            Property("f2", StringType),
-        ).to_dict()
-
-    def detect_primary_keys(self, parquet_filepath: str) -> List[str]:
-        return ["f0"]
+            for filename in [self.config["filepath"]]
+        ]
 
 
 # CLI Execution:


### PR DESCRIPTION
Resolves #1 

This adds automatic schema detection based on parquet metadata.

Note:

1. Not all data types are handled in this PR.
2. Similar to other file-based storage like CSV and JSON, Parquet doesn't natively support the concepts of primary keys or incremental replication keys. These would need to be provided in a custom catalog file, or else specified in future to-be-created tap settings.
